### PR TITLE
Update EIP-7607: Move to Final

### DIFF
--- a/EIPS/eip-7607.md
+++ b/EIPS/eip-7607.md
@@ -4,8 +4,7 @@ title: Hardfork Meta - Fusaka
 description: EIPs included in the Fulu/Osaka Ethereum network upgrade.
 author: Tim Beiko (@timbeiko), Alex Stokes (@ralexstokes), Ansgar Dietrichs (@adietrichs)
 discussions-to: https://ethereum-magicians.org/t/eip-7607-fusaka-meta-eip/18439
-status: Last Call
-last-call-deadline: 2025-10-28
+status: Final
 type: Meta
 created: 2024-02-01
 requires: 7600, 7723
@@ -13,13 +12,11 @@ requires: 7600, 7723
 
 ## Abstract
 
-This Meta EIP lists the EIPs formally Scheduled for Inclusion in the Fulu/Osaka network upgrade. It follows the Pectra upgrade, documented in [EIP-7600](./eip-7600.md)
+This Meta EIP lists the EIPs included in the Fulu/Osaka network upgrade. It follows the Pectra upgrade, documented in [EIP-7600](./eip-7600.md).
 
 ## Specification
 
-Definitions for `Scheduled for Inclusion`, `Considered for Inclusion`, `Proposed for Inclusion` and `Declined for Inclusion` can be found in [EIP-7723](./eip-7723.md).
-
-### EIPs Scheduled for Inclusion
+### Included EIPs
 
 #### Core EIPs
 


### PR DESCRIPTION
With Fusaka activated on mainnet on December 3, 2025, this Meta EIP should be moved to Final.

**Changes:**
- Status: Last Call → Final
- Removed `last-call-deadline` header
- Abstract: "formally Scheduled for Inclusion" → "included"
- Removed definitions line (CFI/PFI/DFI reference to EIP-7723)
- Section header: "EIPs Included" → "Included EIPs" (matches Pectra/Dencun format)

All included EIPs must be moved to Final first:

### Core EIPs
- [ ] EIP-7594: PeerDAS
- [ ] EIP-7823: Set upper bounds for MODEXP
- [ ] EIP-7825: Transaction Gas Limit Cap
- [ ] EIP-7883: ModExp Gas Cost Increase
- [ ] EIP-7917: Deterministic proposer lookahead
- [ ] EIP-7918: Blob base fee bounded by execution cost
- [ ] EIP-7934: RLP Execution Block Size Limit
- [ ] EIP-7939: Count leading zeros (CLZ) opcode
- [ ] EIP-7951: Precompile for secp256r1 Curve Support

### Other EIPs
- [ ] EIP-7892: Blob Parameter Only Hardforks
- [ ] EIP-7642: eth/69 - Drop pre-merge fields
- [ ] EIP-7910: eth_config JSON-RPC Method
- [ ] EIP-7935: Set default gas limit to 60M